### PR TITLE
fix whitespace issues with overflowing horizontal space

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -209,6 +209,10 @@ footer {
   line-height: 1.6;
 }
 
+.blogPost a {
+  word-break: break-all;
+}
+
 .metaData .authorName {
   font-weight: bold;
 }
@@ -318,6 +322,10 @@ td:not(:first-child) {
     overflow-x: auto;
     white-space: nowrap;
   }
+}
+
+.highlight pre {
+  overflow-x: scroll;
 }
 
 /* Small Screens */


### PR DESCRIPTION
Fixes some cosmetic issues:

- When code lines in `pre` tags were wider than the page they force rescaling of content on small phones
- When links overflowed a line, they continues outside of the div instead of wrapping

